### PR TITLE
feat: tryparse returns result, adds serialization

### DIFF
--- a/ModbusTypes.fs
+++ b/ModbusTypes.fs
@@ -1,4 +1,7 @@
 module ModbusTypes
+open Expecto.CSharp
+#nowarn "25"
+
 // for my code, the head should always be the least significant
 
 open Util
@@ -13,7 +16,8 @@ type PDU = byte list
 
 // mbap header = TransactionIdentifier, ProtocolIdentifier (always zero), Length, UnitIdentifier (slave id, typically 1)
 
-type FunctionCode = 
+
+type FunctionCode =
   | Invalid
   | ReadDO
   | ReadDI
@@ -34,21 +38,21 @@ type FunctionCode =
     | WriteReg -> 6uy
     | WriteDOs -> 15uy
     | WriteRegs -> 16uy
-  
+
   static member TryFromByte (x : byte) : Result<FunctionCode,byte> =
     match x with
     | 0uy -> Ok Invalid
-    | 1uy -> Ok ReadDO 
-    | 2uy -> Ok ReadDI  
-    | 3uy -> Ok ReadHReg 
-    | 4uy -> Ok ReadIReg 
+    | 1uy -> Ok ReadDO
+    | 2uy -> Ok ReadDI
+    | 3uy -> Ok ReadHReg
+    | 4uy -> Ok ReadIReg
     | 5uy -> Ok WriteDO
     | 6uy -> Ok WriteReg
     | 15uy -> Ok WriteDOs
-    | 16uy -> Ok WriteRegs 
+    | 16uy -> Ok WriteRegs
     | y -> Error y
 
-type ErrorCode = 
+type ExceptionCode =
   | IllegalFunction     // function code not recognised
   | IllegalDataAddress  // address not allowed
   | IllegalDataValue    // value not allowed
@@ -58,132 +62,193 @@ type ErrorCode =
   | DeviceFailedToRespond  // no response from gateway
   member x.ToByte () : byte =
     match x with
-      | IllegalFunction    -> 1uy 
-      | IllegalDataAddress -> 2uy 
-      | IllegalDataValue   -> 3uy 
-      | SlaveDeviceFailure -> 4uy 
-      | SlaveDeviceBusy    -> 6uy 
-      | PathUnavailable    -> 10uy 
-      | DeviceFailedToRespond -> 11uy     
+      | IllegalFunction    -> 1uy
+      | IllegalDataAddress -> 2uy
+      | IllegalDataValue   -> 3uy
+      | SlaveDeviceFailure -> 4uy
+      | SlaveDeviceBusy    -> 6uy
+      | PathUnavailable    -> 10uy
+      | DeviceFailedToRespond -> 11uy
 
-type ModError = 
+type ModError =
   {
     FunctionCode : FunctionCode
-    ErrorCode : ErrorCode
+    ExceptionCode : ExceptionCode
   }
-  member x.serialize () =
+  member x.Serialize () =
     let exCode = x.FunctionCode.ToByte() + 128uy
-    let erCode = x.ErrorCode.ToByte() 
-    [exCode; erCode]      
+    let erCode = x.ExceptionCode.ToByte()
+    [exCode; erCode]
 
-type ReadDoRequest = 
+type ReadDoRequest =
   {
     Offset : System.UInt16
     Quantity: System.UInt16
   }
-  static member tryParse (pdu : PDU) : ReadDoRequest = 
-    let (fc :: addrH :: addrL :: countH :: countL :: []) = pdu // throw exception if not an exact match
-    {
-      Offset = [addrL; addrH] |> tU16
-      Quantity = [countL; countH] |> tU16
-    }
+  static member TryParse (pdu : PDU) : Result<ReadDoRequest,PDU * exn> =
+    try
+      let (fc :: addrH :: addrL :: countH :: countL :: []) = pdu // throw exception if not an exact match
+      {
+        Offset = [addrL; addrH] |> tU16
+        Quantity = [countL; countH] |> tU16
+      } |> Ok
+    with | e -> (pdu, e) |> Error
+  member x.Serialize () =
+    let [addrL; addrH] = x.Offset |> Util.U16ToBytes
+    let [countL; countH] = x.Quantity |> Util.U16ToBytes
+    let fc = FunctionCode.ReadDO.ToByte()
+    [fc; addrH; addrL; countH; countL]
 
-type ReadDiRequest = 
+type ReadDiRequest =
   {
     Offset : System.UInt16
     Quantity: System.UInt16
   }
-  static member tryParse (pdu : PDU) : ReadDiRequest = 
-    let (fc :: addrH :: addrL :: countH :: countL :: []) = pdu // throw exception if not an exact match
-    {
-      Offset = [addrL; addrH] |> tU16
-      Quantity = [countL; countH] |> tU16
-    }
+  static member TryParse (pdu : PDU) : Result<ReadDiRequest,PDU * exn> =
+    try
+      let (fc :: addrH :: addrL :: countH :: countL :: []) = pdu // throw exception if not an exact match
+      {
+        Offset = [addrL; addrH] |> tU16
+        Quantity = [countL; countH] |> tU16
+      } |> Ok
+    with | e -> (pdu, e) |> Error
+  member x.Serialize () =
+    let [addrL; addrH] = x.Offset |> Util.U16ToBytes
+    let [countL; countH] = x.Quantity |> Util.U16ToBytes
+    let fc = FunctionCode.ReadDI.ToByte()
+    [fc; addrH; addrL; countH; countL]
 
-type ReadHRegRequest = 
+type ReadHRegRequest =
   {
     Offset : System.UInt16
     Quantity: System.UInt16
   }
-  static member tryParse (pdu : byte list) : ReadHRegRequest = 
-    let (fc :: addrH :: addrL :: countH :: countL :: []) = pdu // throw exception if not an exact match
-    {
-      Offset = [addrL; addrH] |> tU16
-      Quantity = [countL; countH] |> tU16
-    }
+  static member TryParse (pdu : byte list) : Result<ReadHRegRequest,PDU * exn> =
+    try
+      let (fc :: addrH :: addrL :: countH :: countL :: []) = pdu // throw exception if not an exact match
+      {
+        Offset = [addrL; addrH] |> tU16
+        Quantity = [countL; countH] |> tU16
+      } |> Ok
+    with | e -> (pdu, e) |> Error
 
-type ReadIRegRequest = 
+  member x.Serialize () = // serialization can't fail
+    let [addrL; addrH] = x.Offset |> Util.U16ToBytes
+    let [countL; countH] = x.Quantity |> Util.U16ToBytes
+    let fc = FunctionCode.ReadHReg.ToByte()
+    [fc; addrH; addrL; countH; countL]
+
+type ReadIRegRequest =
   {
     Offset : System.UInt16
     Quantity: System.UInt16
   }
-  static member tryParse (pdu : byte list) : ReadIRegRequest = 
-    let (fc :: addrH :: addrL :: countH :: countL :: []) = pdu // throw exception if not an exact match
-    {
-      Offset = [addrL; addrH] |> tU16
-      Quantity = [countL; countH] |> tU16
-    }
+  static member TryParse (pdu : byte list) : Result<ReadIRegRequest, PDU * exn > =
+    try
+      let (fc :: addrH :: addrL :: countH :: countL :: []) = pdu // throw exception if not an exact match
+      {
+        Offset = [addrL; addrH] |> tU16
+        Quantity = [countL; countH] |> tU16
+      } |> Ok
+    with | e -> (pdu, e) |> Error
+  member x.Serialize () =
+    let [addrL; addrH] = x.Offset |> Util.U16ToBytes
+    let [countL; countH] = x.Quantity |> Util.U16ToBytes
+    let fc = FunctionCode.ReadIReg.ToByte()
+    [fc; addrH; addrL; countH; countL]
 
-type WriteDoRequest = 
+type WriteDoRequest =
   {
     Offset : System.UInt16
     Value : bool
   }
-  static member tryParse (pdu : byte list) : WriteDoRequest = 
-    let (fc :: addrH :: addrL :: valueH :: valueL :: []) = pdu // throw exception if not an exact match
-    {
-      Offset = [addrL; addrH] |> tU16
-      Value = [valueL; valueH] |> tU16 > 0us
-    }
+  static member TryParse (pdu : byte list) : Result<WriteDoRequest, PDU * exn > =
+    try
+      let (fc :: addrH :: addrL :: valueH :: valueL :: []) = pdu // throw exception if not an exact match
+      {
+        Offset = [addrL; addrH] |> tU16
+        Value = [valueL; valueH] |> tU16 > 0us
+      } |> Ok
+    with | e -> (pdu, e) |> Error
+  member x.Serialize () =
+    let [addrL; addrH] = x.Offset |> Util.U16ToBytes
+    let [valL; valH] = x.Value |> Util.BoolToUint16 |> Util.U16ToBytes
+    let fc = FunctionCode.WriteDO.ToByte()
+    [fc; addrH; addrL; valH; valL]
 
-type WriteRegRequest = 
+type WriteRegRequest =
   {
     Offset : System.UInt16
     Value : System.UInt16
   }
-  static member tryParse (pdu : byte list) : WriteRegRequest = 
-    let (fc :: addrH :: addrL :: valueH :: valueL :: []) = pdu // throw exception if not an exact match
-    {
-      Offset = [addrL; addrH] |> tU16
-      Value = [valueH; valueL] |> tU16
-    }
+  static member TryParse (pdu : byte list) : Result<WriteRegRequest, PDU * exn> =
+    try
+      let (fc :: addrH :: addrL :: valueH :: valueL :: []) = pdu // throw exception if not an exact match
+      {
+        Offset = [addrL; addrH] |> tU16
+        Value = [valueH; valueL] |> tU16
+      } |> Ok
+    with | e -> (pdu, e) |> Error
+  member x.Serialize () =
+    let [addrL; addrH] = x.Offset |> Util.U16ToBytes
+    let [valL; valH] = x.Value |> Util.U16ToBytes
+    let fc = FunctionCode.WriteReg.ToByte()
+    [fc; addrH; addrL; valH; valL]
 
-type WriteDosRequest = 
+type WriteDosRequest =
   {
     Offset : System.UInt16
     Quantity: System.UInt16
-    ByteCount: byte
+    // cannot be inferred, this information is needed
+    // by the response
+    // ByteCount: byte // useful for parsing validation, though
     Values: bool list
   }
-  static member tryParse (pdu : byte list) : WriteDosRequest = 
-    let (fc :: addrH :: addrL :: countH :: countL :: count :: values) = pdu // throw exception if not an exact match
-    {
-      Offset = [addrL; addrH] |> tU16
-      Quantity = [countL; countH] |> tU16
-      ByteCount = count
-      Values = values |> Util.bytesToBool
-    }  
+  static member TryParse (pdu : byte list) : Result<WriteDosRequest, PDU * exn> =
+    try
+      let (fc :: addrH :: addrL :: countH :: countL :: byteCount :: values) = pdu // throw exception if not an exact match
+      {
+        Offset = [addrL; addrH] |> tU16
+        Quantity = [countL; countH] |> tU16
+        Values = values |> Util.bytesToBool
+      } |> Ok
+    with | e -> (pdu, e) |> Error
+    member x.Serialize () =
+      let [addrL; addrH] = x.Offset |> Util.U16ToBytes
+      let [countL; countH] = x.Quantity |> Util.U16ToBytes
+      let data = x.Values |> Util.BoolsToBytes
+      let byteCount = data |> List.length |> byte
+      let fc = FunctionCode.WriteDOs.ToByte()
+      [fc; addrH; addrL; countH; countL; byteCount] @ data
 
-type WriteRegsRequest = 
+type WriteRegsRequest =
   {
     Offset : System.UInt16
     Quantity : System.UInt16
-    ByteCount: byte
+    //ByteCount: byte
     Values : System.UInt16 list
   }
-  static member tryParse (pdu : byte list) : WriteRegsRequest = 
-    let (fc :: addrH :: addrL :: countH :: countL :: count :: values) = pdu // throw exception if not an exact match
-    if values.Length % 2 <> 0 then
-      "Even number of data bytes expected" |> FormatException |> raise
+  static member TryParse (pdu : byte list) : Result<WriteRegsRequest,PDU * exn> =
+    try
+      let (fc :: addrH :: addrL :: countH :: countL :: count :: values) = pdu // throw exception if not an exact match
+      if values.Length % 2 <> 0 then
+        "Even number of data bytes expected" |> FormatException |> raise
 
-    {
-      Offset = [addrL; addrH] |> tU16
-      Quantity = [countL; countH] |> tU16
-      ByteCount = count
-      Values = values |> Util.bytesToUint16
-    }    
+      {
+        Offset = [addrL; addrH] |> tU16
+        Quantity = [countL; countH] |> tU16
+        Values = values |> Util.bytesToUint16
+      } |> Ok
+    with | e -> (pdu, e) |> Error
+    member x.Serialize () =
+      let [addrL; addrH] = x.Offset |> Util.U16ToBytes
+      let [countL; countH] = x.Quantity |> Util.U16ToBytes
+      let data = x.Values |> Util.U16sToBytes |> Util.swapU16s
+      let byteCount = data |> List.length |> byte
+      let fc = FunctionCode.WriteRegs.ToByte()
+      [fc; addrH; addrL; countH; countL; byteCount] @ data
 
-type Request = 
+type Request =
   | ReadDOReq of ReadDoRequest
   | ReadDIReq of ReadDiRequest
   | ReadHRegReq of ReadHRegRequest
@@ -194,178 +259,195 @@ type Request =
   | WriteRegsReq of WriteRegsRequest
   | ModErrorReq of ModError
 
-type ReadDoResponse = 
-  {
-    Status: bool list 
-  }
-  member x.serialize () : byte list = 
-    let status = x.Status |> Util.BoolsToBytes
-    let c = status |> List.length |> byte
-    [1uy; c] @ status
-  
-  static member tryParse (pdu : PDU) : ReadDoResponse = 
-    let (fc :: count :: data) = pdu // throw exception if not an exact match
-    {
-      Status = data |> bytesToBool
-    }
-
-type ReadDiResponse = 
+type ReadDoResponse =
   {
     Status: bool list
   }
-  member x.serialize () : byte list = 
+  member x.Serialize ()  : byte list =
     let status = x.Status |> Util.BoolsToBytes
     let c = status |> List.length |> byte
-    [2uy; c] @ status  
+    let fc = FunctionCode.ReadDO.ToByte()
+    [fc; c] @ status
 
-  static member tryParse (pdu : PDU) : ReadDiResponse = 
-    let (fc :: count :: data) = pdu // throw exception if not an exact match
-    {
-      Status = data |> bytesToBool
-    }    
+  static member TryParse (pdu : PDU) : Result<ReadDoResponse, PDU * exn> =
+    try
+      let (fc :: count :: data) = pdu // throw exception if not an exact match
+      {
+        Status = data |> bytesToBool
+      } |> Ok
+    with | e -> (pdu, e) |> Error
 
-type ReadHRegResponse = 
+type ReadDiResponse =
+  {
+    Status: bool list
+  }
+  member x.Serialize ()  : byte list =
+    let status = x.Status |> Util.BoolsToBytes
+    let c = status |> List.length |> byte
+    let fc = FunctionCode.ReadDI.ToByte()
+    [fc; c] @ status
+
+  static member TryParse (pdu : PDU) : Result<ReadDiResponse, PDU * exn> =
+    try
+      let (fc :: count :: data) = pdu // throw exception if not an exact match
+      {
+        Status = data |> bytesToBool
+      } |> Ok
+    with | e -> (pdu, e) |> Error
+
+type ReadHRegResponse =
   {
     Values : UInt16 list
   }
-  member x.serialize () : byte list = 
-    let count = x.Values |> List.length |> (*)2 |> byte
-    let data = x.Values |> Util.U16sToBytes 
+  member x.Serialize ()  : byte list =
+    let data = x.Values |> Util.U16sToBytes |> swapU16s
+    let count = data |> List.length |> byte
+
     [3uy; count] @ data
 
-  static member tryParse (pdu : PDU) : ReadHRegResponse = 
-    let (fc :: count :: data) = pdu // throw exception if not an exact match
-    {
-      Values = data |> bytesToUint16
-    }
-    
+  static member TryParse (pdu : PDU) : Result<ReadHRegResponse, PDU * exn> =
+    try
+      let (fc :: count :: data) = pdu // throw exception if not an exact match
+      {
+        Values = data |> bytesToUint16
+      } |> Ok
+    with | e -> (pdu, e) |> Error
 
-type ReadIRegResponse = 
+type ReadIRegResponse =
   {
     Values : UInt16 list
   }
-  member x.serialize () : byte list = 
-    let count = x.Values |> List.length |> (*)2 |> byte
-    let data = x.Values |> Util.U16sToBytes |> Util.swapU16s
-    [4uy; count] @ data
+  member x.Serialize ()  : byte list =
+    let data = x.Values |> Util.U16sToBytes |> swapU16s
+    let count = data |> List.length |> byte
+    let fc = FunctionCode.ReadIReg.ToByte()
+    [fc; count] @ data
 
-  static member tryParse (pdu : PDU) : ReadIRegResponse = 
-    let (fc :: count :: data ) = pdu // throw exception if not an exact match
-    {
-      Values = data |> bytesToUint16
-    }    
+  static member TryParse (pdu : PDU) : Result<ReadIRegResponse, PDU * exn> =
+    try
+      let (fc :: count :: data ) = pdu // throw exception if not an exact match
+      {
+        Values = data |> bytesToUint16
+      } |> Ok
+    with | e -> (pdu, e) |> Error
 
 
-type WriteDoResponse = 
+type WriteDoResponse =
   {
     Offset: UInt16
     Value: bool
   }
-  member x.serialize () : byte list = 
-    let oBytes = x.Offset |> Util.U16ToBytes
-    let oVal = x.Value |> Util.BoolToUint16 |> Util.U16ToBytes
-    [5uy] @ oBytes @ oVal
+  member x.Serialize ()  : byte list =
+    let oBytes = x.Offset |> U16ToBytes |> swapU16s
+    let oVal = x.Value |> BoolToUint16 |> U16ToBytes |> swapU16s
+    let fc = FunctionCode.WriteDO.ToByte()
+    fc :: oBytes @ oVal
 
-  static member tryParse (pdu : PDU) : WriteDoResponse = 
-    let (fc :: offsetH :: offsetL :: valH :: valL) = pdu // throw exception if not an exact match
-    {
-      Offset = [offsetH; offsetL] |> tU16
-      Value = valH = 255uy
-    }        
+  static member TryParse (pdu : PDU) : Result<WriteDoResponse, PDU * exn>  =
+    try
+      let (fc :: offsetH :: offsetL :: valH :: valL :: []) = pdu // throw exception if not an exact match
+      {
+        Offset = [offsetH; offsetL] |> tU16
+        Value = valH = 255uy
+      } |> Ok
+
+    with | e -> (pdu, e) |> Error
 
 
-type WriteRegResponse = 
+type WriteRegResponse =
   {
     Offset: UInt16
     Value: UInt16
   }
-  member x.serialize () : byte list = 
-    let oBytes = x.Offset |> Util.U16ToBytes |> List.rev
-    let oVal = x.Value |> Util.U16ToBytes
-    [6uy] @ oBytes @ oVal
+  member x.Serialize ()  : byte list =
+    let oBytes = x.Offset |> Util.U16ToBytes |> swapU16s
+    let oVal = x.Value |> Util.U16ToBytes |> swapU16s
+    let fc = FunctionCode.WriteReg.ToByte()
+    fc :: oBytes @ oVal
 
-type WriteDosResponse = 
+type WriteDosResponse =
   {
     Offset: UInt16
     Count: UInt16
   }
-  member x.serialize () : byte list = 
-    let oOffset = x.Offset |> Util.U16ToBytes |> List.rev
-    let oCount = x.Count |> Util.U16ToBytes |> List.rev
-    [15uy] @ oOffset @ oCount 
+  member x.Serialize ()  : byte list =
+    let oOffset = x.Offset |> Util.U16ToBytes |> swapU16s
+    let oCount = x.Count |> Util.U16ToBytes |> swapU16s
+    let fc = FunctionCode.WriteDOs.ToByte()
+    fc :: oOffset @ oCount
 
-type WriteRegsResponse = 
+type WriteRegsResponse =
   {
     Offset: UInt16
     Count: UInt16
   }
-  member x.serialize () : byte list = 
-    let oOffset = x.Offset |> Util.U16ToBytes |> List.rev
-    let oCount = x.Count |> Util.U16ToBytes |> List.rev
-    [16uy] @ oOffset @ oCount   
+  member x.Serialize ()  : byte list =
+    let oOffset = x.Offset |> U16ToBytes |> swapU16s
+    let oCount = x.Count |> U16ToBytes |> swapU16s
+    [16uy] @ oOffset @ oCount
 
-  static member TryFromByte (x : byte) : Result<ErrorCode,byte> =
+  static member TryFromByte (x : byte) : Result<ExceptionCode,byte> =
     match x with
-    | 1uy -> Ok IllegalFunction 
-    | 2uy -> Ok IllegalDataAddress  
-    | 3uy -> Ok IllegalDataValue 
-    | 4uy -> Ok SlaveDeviceFailure 
-    | 6uy -> Ok SlaveDeviceBusy 
-    | 10uy -> Ok PathUnavailable 
+    | 1uy -> Ok IllegalFunction
+    | 2uy -> Ok IllegalDataAddress
+    | 3uy -> Ok IllegalDataValue
+    | 4uy -> Ok SlaveDeviceFailure
+    | 6uy -> Ok SlaveDeviceBusy
+    | 10uy -> Ok PathUnavailable
     | 11uy -> Ok DeviceFailedToRespond
     | y -> Error y
 
-type Response = 
-  | ReadDORes of ReadDoResponse 
+type Response =
+  | ReadDORes of ReadDoResponse
   | ReadDIRes of ReadDiResponse
   | ReadHRegRes of ReadHRegResponse
   | ReadIRegRes of ReadIRegResponse
   | WriteDORes of WriteDoResponse
   | WriteRegRes of WriteRegResponse
   | WriteDOsRes of WriteDosResponse
-  | WriteRegsRes of WriteRegsResponse  
+  | WriteRegsRes of WriteRegsResponse
   | ModErrorRes of ModError
-  member x.serialize () : byte list = 
+  member x.Serialize ()  : byte list =
     match x with
-    | ReadDORes y    -> y.serialize ()
-    | ReadDIRes y    -> y.serialize ()
-    | ReadHRegRes y  -> y.serialize ()
-    | ReadIRegRes y  -> y.serialize ()
-    | WriteDORes y   -> y.serialize ()
-    | WriteRegRes y  -> y.serialize ()
-    | WriteDOsRes y  -> y.serialize ()
-    | WriteRegsRes y -> y.serialize ()
-    | ModErrorRes y -> y.serialize ()
+    | ReadDORes x -> x.Serialize ()
+    | ReadDIRes x -> x.Serialize ()
+    | ReadHRegRes x -> x.Serialize ()
+    | ReadIRegRes x -> x.Serialize ()
+    | WriteDORes x -> x.Serialize ()
+    | WriteRegRes x -> x.Serialize ()
+    | WriteDOsRes x -> x.Serialize ()
+    | WriteRegsRes x -> x.Serialize ()
+    | ModErrorRes x -> x.Serialize ()
 
-type Mbap = 
+type Mbap =
   {
     TransactionIdentifier : TransactionIdentifier
     ProtocolIdentifier : ProtocolIdentifier
     Length : Length
     UnitIdentifier : UnitIdentifier
   }
-  member x.serialize () : byte list = 
+  member x.Serialize ()  : byte list =
     // The transaction and protocol identifiers are reversed
-    let ti = x.TransactionIdentifier |> U16ToBytes |> List.rev
-    let pi = x.ProtocolIdentifier |> U16ToBytes |> List.rev
-    let len = x.Length |> U16ToBytes |> List.rev
+    let ti = x.TransactionIdentifier |> U16ToBytes |> swapU16s
+    let pi = x.ProtocolIdentifier |> U16ToBytes |> swapU16s
+    let len = x.Length |> U16ToBytes |> swapU16s
     let uid = x.UnitIdentifier
 
     ti @ pi @ len @ [uid]
 
-  static member wrapPdu (reqMbap : Mbap) (pdu : PDU) : byte list = 
+  static member wrapPdu (reqMbap : Mbap) (pdu : PDU) : byte list =
     let nlen = pdu |> List.length |> uint16 |> (+)1us
-    let nMbap = 
+    let nMbap =
       {
         TransactionIdentifier = reqMbap.TransactionIdentifier
         ProtocolIdentifier = reqMbap.ProtocolIdentifier
         Length = nlen
         UnitIdentifier = reqMbap.UnitIdentifier
       }
-    nMbap.serialize() @ pdu @ []
+    nMbap.Serialize () @ pdu @ []
 
 // delegates that are called for each type of function
-type ModFuncs = 
+type ModFuncs =
   {
     ReadDOFunc    : ReadDoRequest -> ReadDoResponse
     ReadDIFunc    : ReadDiRequest -> ReadDiResponse
@@ -380,8 +462,8 @@ type ModFuncs =
   // the defaults do nothing, all they do is return is
   // the expected corresponding successful response
   static member defaultSuccesses =
-    let expected q = 
-      q / 8us + 1us 
+    let expected q =
+      q / 8us + 1us
       |> fun x -> [1us..x]
       |> List.map (fun _ -> 0uy)
       |> fun x -> 1uy :: (x |> List.tail)
@@ -392,39 +474,39 @@ type ModFuncs =
       |> List.map(fun _ -> 0us)
       |> fun x -> 1us :: (x |> List.tail)
 
-    let readDoFunc (x : ReadDoRequest) : ReadDoResponse = 
-      { 
-        Status = expected x.Quantity
-      }
-    
-    let readDiFunc (x : ReadDiRequest) : ReadDiResponse = 
+    let readDoFunc (x : ReadDoRequest) : ReadDoResponse =
       {
         Status = expected x.Quantity
       }
 
-    let readHRegFunc (x : ReadHRegRequest) : ReadHRegResponse = 
+    let readDiFunc (x : ReadDiRequest) : ReadDiResponse =
+      {
+        Status = expected x.Quantity
+      }
+
+    let readHRegFunc (x : ReadHRegRequest) : ReadHRegResponse =
       {
         Values = expected16 x.Quantity
       }
 
-    let readIRegFunc (x : ReadIRegRequest) : ReadIRegResponse = 
+    let readIRegFunc (x : ReadIRegRequest) : ReadIRegResponse =
       {
         Values = expected16 x.Quantity
       }
 
-    let writeDoFunc (x : WriteDoRequest) : WriteDoResponse = 
+    let writeDoFunc (x : WriteDoRequest) : WriteDoResponse =
       {
         Offset = x.Offset
         Value = x.Value
       }
 
-    let writeRegFunc (x : WriteRegRequest) : WriteRegResponse = 
+    let writeRegFunc (x : WriteRegRequest) : WriteRegResponse =
       {
         Offset = x.Offset
         Value = x.Value
       }
 
-    let writeDOsFunc (x : WriteDosRequest) : WriteDosResponse = 
+    let writeDOsFunc (x : WriteDosRequest) : WriteDosResponse =
       {
         Count = x.Quantity
         Offset = x.Offset
@@ -445,29 +527,29 @@ type ModFuncs =
       WriteDOsFunc  = writeDOsFunc
       WriteRegsFunc = writeRegsFunc
       ModErrorFunc  = fun x -> x
-    }    
-    
+    }
 
-type ModbusServerConf = 
+
+type ModbusServerConf =
   {
     Port : System.UInt32
     IPAddress : System.Net.IPAddress
     SlaveId: byte
   }
-  static member TryParse (str : string) : Result<ModbusServerConf, string> = 
+  static member TryParse (str : string) : Result<ModbusServerConf, string> =
     // string expected in the format tcp://127.0.0.1:502
     let str = str.ToLower()
     match str.IndexOf("tcp://") with
-    | 0 -> 
+    | 0 ->
       let str1 = str.Split("tcp://") |> Array.last
-      match str1.Split(":") with 
-      | [|addr; port|] -> 
+      match str1.Split(":") with
+      | [|addr; port|] ->
         let resIP = ref (System.Net.IPAddress(0L))
         let successIP = System.Net.IPAddress.TryParse(addr, resIP)
         let resPort = ref 0u
         let successPort = System.UInt32.TryParse(port, resPort)
         match successIP, successPort  with
-        | true, true -> 
+        | true, true ->
           {
             Port = resPort.Value
             IPAddress = resIP.Value
@@ -476,4 +558,3 @@ type ModbusServerConf =
         | _ -> Error str
       | _ -> Error str
     | _ -> Error str
-  

--- a/tests/Serialization.fs
+++ b/tests/Serialization.fs
@@ -3,10 +3,769 @@ module Test.Serialization
 open Hopac
 open Expecto
 open ModbusTypes
+open Util
 
-let tests = 
+let tests =
     testList "Serialization" [
-        test "ModError" {
-            Expect.equal 1 1 "should be one"
-        }
+        testList "ReadDOError" [ // this is simple, i'm satisfied with just a couple tests
+            test "IllegalDataAddress" {
+                let t = {
+                    FunctionCode = ReadDO
+                    ExceptionCode = IllegalDataAddress
+                }
+
+                Expect.equal
+                  (t.Serialize ())
+                  [(128uy + 1uy); 2uy]
+                  "[129, 2] expected"
+            }
+            test "SlaveDeviceFailure" {
+                let t = {
+                    FunctionCode = ReadDO
+                    ExceptionCode = SlaveDeviceFailure
+                }
+
+                Expect.equal
+                  (t.Serialize ())
+                  [(128uy + 1uy); 4uy]
+                  "[129, 4] expected"
+            }
+            test "SlaveDeviceBusy" {
+                let t = {
+                    FunctionCode = ReadDO
+                    ExceptionCode = SlaveDeviceBusy
+                }
+
+                Expect.equal
+                  (t.Serialize ())
+                  [(128uy + 1uy); 6uy]
+                  "[129, 6] expected"
+            }
+        ]
+        testList "WriteHRegError" [
+            test "IllegalDataAddress" {
+                let t = {
+                    FunctionCode = WriteReg
+                    ExceptionCode = IllegalDataAddress
+                }
+
+                Expect.equal
+                  (t.Serialize ())
+                  [(128uy + 6uy); 2uy]
+                  "[134, 2] expected"
+            }
+            test "SlaveDeviceFailure" {
+                let t = {
+                    FunctionCode = WriteReg
+                    ExceptionCode = SlaveDeviceFailure
+                }
+
+                Expect.equal
+                  (t.Serialize ())
+                  [(128uy + 6uy); 4uy]
+                  "[134, 4] expected"
+            }
+            test "SlaveDeviceBusy" {
+                let t = {
+                    FunctionCode = WriteReg
+                    ExceptionCode = SlaveDeviceBusy
+                }
+
+                Expect.equal
+                  (t.Serialize ())
+                  [(128uy + 6uy); 6uy]
+                  "[134, 6] expected"
+            }
+        ]
+        testList "ReadDoRequest" [
+            test "LSB Only" {
+                let t : ReadDoRequest = {
+                    Offset = 32us
+                    Quantity = 16us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [1uy; 0uy; 32uy; 0uy; 16uy]
+                  "[1uy; 0uy; 32uy; 0uy; 16uy] "
+            }
+            test "MSB Only" {
+                let t : ReadDoRequest = {
+                    Offset = 512us
+                    Quantity = 1024us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [1uy; 2uy; 0uy; 4uy; 0uy]
+                  "[1uy; 0uy; 32uy; 0uy; 16uy] "
+            }
+            test "MSB & LSB" {
+                let t : ReadDoRequest = {
+                    Offset = 512us + 32us
+                    Quantity = 1024us + 16us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [1uy; 2uy; 32uy; 4uy; 16uy]
+                  "[1uy; 0uy; 32uy; 0uy; 16uy] "
+            }
+        ]
+        testList "ReadDiRequest" [
+            test "LSB Only" {
+                let t : ReadDiRequest = {
+                    Offset = 32us
+                    Quantity = 16us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [2uy; 0uy; 32uy; 0uy; 16uy]
+                  "[2uy; 0uy; 32uy; 0uy; 16uy] "
+            }
+            test "MSB Only" {
+                let t : ReadDiRequest = {
+                    Offset = 512us
+                    Quantity = 1024us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [2uy; 2uy; 0uy; 4uy; 0uy]
+                  "[2uy; 0uy; 32uy; 0uy; 16uy] "
+
+            }
+            test "MSB & LSB" {
+                let t : ReadDiRequest = {
+                    Offset = 512us + 32us
+                    Quantity = 1024us + 16us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [2uy; 2uy; 32uy; 4uy; 16uy]
+                  "[2uy; 0uy; 32uy; 0uy; 16uy] "
+            }
+        ]
+        testList "ReadHRegRequest" [
+            test "LSB Only" {
+                let t : ReadHRegRequest = {
+                    Offset = 32us
+                    Quantity = 16us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [3uy; 0uy; 32uy; 0uy; 16uy]
+                  "[3uy; 0uy; 32uy; 0uy; 16uy] "
+
+            }
+            test "MSB Only" {
+                let t : ReadHRegRequest = {
+                    Offset = 512us
+                    Quantity = 1024us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [3uy; 2uy; 0uy; 4uy; 0uy]
+                  "[3uy; 0uy; 32uy; 0uy; 16uy] "
+            }
+            test "MSB & LSB" {
+                let t : ReadHRegRequest = {
+                    Offset = 512us + 32us
+                    Quantity = 1024us + 16us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [3uy; 2uy; 32uy; 4uy; 16uy]
+                  "[3uy; 0uy; 32uy; 0uy; 16uy] "
+            }
+        ]
+        testList "ReadIRegRequest" [
+            test "LSB Only" {
+                let t : ReadIRegRequest = {
+                    Offset = 32us
+                    Quantity = 16us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [4uy; 0uy; 32uy; 0uy; 16uy]
+                  "[4uy; 0uy; 32uy; 0uy; 16uy] "
+            }
+            test "MSB Only" {
+                let t : ReadIRegRequest = {
+                    Offset = 512us
+                    Quantity = 1024us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [4uy; 2uy; 0uy; 4uy; 0uy]
+                  "[4uy; 0uy; 32uy; 0uy; 16uy] "
+            }
+            test "MSB & LSB" {
+                let t : ReadIRegRequest = {
+                    Offset = 512us + 32us
+                    Quantity = 1024us + 16us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [4uy; 2uy; 32uy; 4uy; 16uy]
+                  "[4uy; 0uy; 32uy; 0uy; 16uy] "
+            }
+        ]
+        testList "WriteDoRequest" [
+            test "LSB Only true" {
+                let t : WriteDoRequest = {
+                    Offset = 32us
+                    Value = true
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [5uy; 0uy; 32uy; 0xFFuy; 00uy]
+                  "[5uy; 0uy; 32uy; 0xFFuy; 0uy] "
+            }
+            test "LSB Only false" {
+                let t : WriteDoRequest = {
+                    Offset = 32us
+                    Value = false
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [5uy; 0uy; 32uy; 0x00uy; 00uy]
+                  "[5uy; 0uy; 32uy; 0x00uy; 0uy] "
+            }
+            test "LSB&MSB true" {
+                let t : WriteDoRequest = {
+                    Offset = 512us + 32us
+                    Value = true
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [5uy; 2uy; 32uy; 0xFFuy; 00uy]
+                  "[5uy; 2uy; 32uy; 0xFFuy; 0uy] "
+            }
+        ]
+        testList "WriteRegRequest" [
+            test "LSB Only" {
+                let t : WriteRegRequest = {
+                    Offset = (0x00us <<< 8) + 0x32us
+                    Value = (0x00us <<< 8) + 0x55us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [6uy; 0uy; 0x32uy; 0x00uy; 0x55uy]
+                  "[6uy; 0uy; 32uy; 0xFFuy; 0uy] "
+            }
+            test "LSBs & MSB" {
+                let t : WriteRegRequest = {
+                    Offset = (0x66us <<< 8) + 0x32us
+                    Value = (0xA9us <<< 8) + 0x55us
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [6uy; 0x66uy; 0x32uy; 0xA9uy; 0x55uy]
+                  "[6uy; 0uy; 32uy; 0x00uy; 0uy] "
+            }
+        ]
+
+        testList "WriteDosRequest" [
+            test "6 values" {
+                let t : WriteDosRequest = {
+                    Offset = (0x66us <<< 8) + 0x32us
+                    Quantity = (0x00us <<< 8) + 06us
+                    Values = [true; true; true; true; false; false; false; false;]
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [15uy; 0x66uy; 0x32uy; 0x00uy; 0x06uy; 1uy; 15uy]
+                  "[15uy; 0x66uy; 0x32uy; 0x00uy; 0x06uy; 1uy; 15uy]"
+            }
+            test "8 values" {
+                let t : WriteDosRequest = {
+                    Offset = (0x66us <<< 8) + 0x32us
+                    Quantity = (0x00us <<< 8) + 08us
+                    Values = [true; true; true; true; false; false; false; true;]
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [15uy; 0x66uy; 0x32uy; 0x00uy; 0x08uy; 1uy; 143uy]
+                  "[15uy; 0x66uy; 0x32uy; 0x00uy; 0x08uy; 1uy; 143uy]"
+            }
+            test "12 values" {
+                let t : WriteDosRequest = {
+                    Offset = (0x66us <<< 8) + 0x32us
+                    Quantity = (0x00us <<< 8) + 12us
+                    Values =
+                      [
+                        true;
+                        true;
+                        true;
+                        true;
+                        false;
+                        false;
+                        false;
+                        true;
+                        // ---
+                        true;
+                        true;
+                        false;
+                        false;
+                        false;
+                        false;
+                        false;
+                        false;
+                        ]
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [15uy; 0x66uy; 0x32uy; 0x00uy; 12uy; 2uy; 143uy; 3uy]
+                  "[15uy; 0x66uy; 0x32uy; 0x00uy; 12uy; 2uy; 143uy; 3uy]"
+            }
+            test "20 values" {
+                let t : WriteDosRequest = {
+                    Offset = (0x66us <<< 8) + 0x32us
+                    Quantity = (0x00us <<< 8) + 20us
+                    Values =
+                      [
+                        true;
+                        true;
+                        true;
+                        true;
+                        false;
+                        false;
+                        false;
+                        true;
+                        // ---
+                        true;
+                        true;
+                        false;
+                        false;
+                        false;
+                        false;
+                        false;
+                        false;
+                        // ---
+                        true;
+                        true;
+                        true;
+                        true;
+                        false;
+                        false;
+                        false;
+                        false;
+                        ]
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [15uy; 0x66uy; 0x32uy; 0x00uy; 20uy; 3uy; 143uy; 3uy; 15uy;]
+                  "[15uy; 0x66uy; 0x32uy; 0x00uy; 20uy; 3uy; 143uy; 3uy; ]"
+            }
+            test "240 values" {
+                let t : WriteDosRequest = {
+                    Offset = (0x66us <<< 8) + 0x32us
+                    Quantity = 1920us
+                    Values = [0..1919] |> List.map (fun x -> x % 2 = 0)
+                }
+                let expectedData = [1..(240)] |> List.map (fun _ -> 85uy)
+                // 1920 = 07 80
+
+                Expect.equal
+                  (t.Serialize ())
+                  ([15uy; 0x66uy; 0x32uy; 0x07uy; 0x80uy; 240uy; ] @ expectedData)
+                  "[15uy; 0x66uy; 0x32uy; 0x07uy; 0x80uy; 240uy; ...]"
+            }
+        ]
+
+        testList "WriteRegsRequest" [
+            test "1 value" {
+                let t : WriteRegsRequest = {
+                    Offset = (0x66us <<< 8) + 0x32us
+                    Quantity = (0x00us <<< 8) + 01us
+                    Values = [1us]
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [16uy; 0x66uy; 0x32uy; 0x00uy; 0x01uy; 2uy; 0uy; 1uy]
+                  "[16uy; 0x66uy; 0x32uy; 0x00uy; 0x01uy; 2uy; 0uy; 1uy]"
+            }
+            test "2 large values" {
+                let t : WriteRegsRequest = {
+                    Offset = (0x66us <<< 8) + 0x32us
+                    Quantity = (0x00us <<< 8) + 02us
+                    Values = [33003us; 18711us] // head = least sig
+                    // 80 EB 49 17
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [16uy; 0x66uy; 0x32uy; 0x00uy; 0x02uy; 4uy; 0x80uy; 0xEBuy; 0x49uy; 0x17uy]
+                  "[16uy; 0x66uy; 0x32uy; 0x00uy; 0x01uy; 2uy; ...]"
+            }
+            test "120 values" {
+                let v = [1us..120us] |> List.map ((*) 200us) // head = least sig
+                let t : WriteRegsRequest = {
+                    Offset = (0x66us <<< 8) + 0x32us
+                    Quantity = (0x00us <<< 8) + 120us
+                    Values = v
+                }
+                let expectedData = v |> U16sToBytes |> swapU16s
+                Expect.equal
+                  (t.Serialize ())
+                  ([16uy; 0x66uy; 0x32uy; 0uy; 120uy; 240uy] @ expectedData)
+                  "[16uy; 0x66uy; 0x32uy; 0uy; 120uy; 240uy;...]"
+            }
+        ]
+
+        testList "ReadDoResponse" [
+            // the client needs to keep track
+            // of the transaction, the offset and requested quantity
+            // so much complexity to save a few bytes!
+            test "1 byte" {
+                let t : ReadDoResponse = {
+                    Status = [true; true; true; true; false; false; false; false;]
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [1uy; 0x01uy; 15uy]
+                  "[1uy; 0x01uy; 15uy]"
+            }
+            test "3 bytes" {
+                let t : ReadDoResponse = {
+                    Status =
+                      [
+                        true;
+                        true;
+                        true;
+                        true;
+                        false;
+                        false;
+                        false;
+                        true;
+                        // ---
+                        true;
+                        true;
+                        false;
+                        false;
+                        false;
+                        false;
+                        false;
+                        false;
+                        // ---
+                        true;
+                        true;
+                        true;
+                        true;
+                        false;
+                        false;
+                        false;
+                        false;
+                      ]
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [1uy; 0x03uy; 143uy; 3uy; 15uy]
+                  "[1uy; 0x03uy; 143uy; 3uy; 15uy]"
+            }
+
+        ]
+        testList "ReadDiResponse" [
+            // the client needs to keep track
+            // of the transaction, the offset and requested quantity
+            // so much complexity to save a few bytes!
+            test "1 byte" {
+                let t : ReadDiResponse = {
+                    Status = [true; true; true; true; false; false; false; false;]
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [2uy; 0x01uy; 15uy]
+                  "[2uy; 0x01uy; 15uy]"
+            }
+
+            test "2 bytes" {
+                let t : ReadDiResponse = {
+                    Status =
+                      [
+                          true;
+                          true;
+                          true;
+                          true;
+                          false;
+                          false;
+                          false;
+                          false;
+                          // ---
+                          false;
+                          true;
+                          false;
+                          false;
+                          false;
+                          false;
+                          false;
+                          false;
+                      ]
+                }
+                Expect.equal
+                  (t.Serialize ())
+                  [2uy; 0x02uy; 15uy; 2uy]
+                  "[2uy; 0x02uy; 15uy; 2uy]"
+            }
+
+        ]
+
+        testList "ReadHRegResponse" [
+            // the client needs to keep track
+            // of the transaction, the offset and requested quantity
+            // so much complexity to save a few bytes!
+            test "10 values" {
+                let v1 = [1us..5us]
+                let v2 = [512us..516us]
+                let t : ReadHRegResponse = {
+                    Values = v1 @ v2
+                }
+
+                let expected =
+                  [
+                    3uy;
+                    20uy;
+                    0uy; 1uy;
+                    0uy; 2uy;
+                    0uy; 3uy;
+                    0uy; 4uy;
+                    0uy; 5uy;
+                    2uy; 0uy;
+                    2uy; 1uy;
+                    2uy; 2uy;
+                    2uy; 3uy;
+                    2uy; 4uy
+                  ]
+
+                Expect.equal
+                  (t.Serialize ())
+                  expected
+                  "[3uy; 20uy; 00uy; 01uy...]"
+            }
+
+
+        ]
+
+        testList "ReadIRegResponse" [
+            // the client needs to keep track
+            // of the transaction, the offset and requested quantity
+            // so much complexity to save a few bytes!
+            test "10 values" {
+                let v1 = [1us..5us]
+                let v2 = [512us..516us]
+                let t : ReadIRegResponse = {
+                    Values = v1 @ v2
+                }
+
+                let expected =
+                  [
+                    4uy;
+                    20uy;
+                    0uy; 1uy;
+                    0uy; 2uy;
+                    0uy; 3uy;
+                    0uy; 4uy;
+                    0uy; 5uy;
+                    2uy; 0uy;
+                    2uy; 1uy;
+                    2uy; 2uy;
+                    2uy; 3uy;
+                    2uy; 4uy
+                  ]
+
+                Expect.equal
+                  (t.Serialize ())
+                  expected
+                  "[4uy; 20uy; 00uy; 01uy...]"
+            }
+
+
+        ]
+
+        testList "WriteDoResponse" [
+            // the client needs to keep track
+            // of the transaction, the offset and requested quantity
+            // so much complexity to save a few bytes!
+            test "true" {
+                let t : WriteDoResponse = {
+                    Offset = 0x20us
+                    Value = true
+                }
+
+                let expected =
+                  [
+                    5uy;
+                    0x00uy;
+                    0x20uy;
+                    0xffuy;
+                    0x00uy;
+                  ]
+
+                Expect.equal
+                  (t.Serialize ())
+                  expected
+                  "[5uy; 00uy; 20uy; 0xffuy; 00uy]"
+            }
+
+            test "false" {
+                let t : WriteDoResponse = {
+                    Offset = 0x20us
+                    Value = false
+                }
+
+                let expected =
+                  [
+                    5uy;
+                    0x00uy;
+                    0x20uy;
+                    0x00uy;
+                    0x00uy;
+                  ]
+
+                Expect.equal
+                  (t.Serialize ())
+                  expected
+                  "[5uy; 00uy; 20uy; 0x00uy; 00uy]"
+            }
+
+            test "true high address" {
+                let t : WriteDoResponse = {
+                    Offset = 0x2120us
+                    Value = true
+                }
+
+                let expected =
+                  [
+                    5uy;
+                    0x21uy;
+                    0x20uy;
+                    0xffuy;
+                    0x00uy;
+                  ]
+
+                Expect.equal
+                  (t.Serialize ())
+                  expected
+                  "[5uy; 0x21uy; 0x20uy; 0xffuy; 00uy]"
+            }
+        ]
+
+        testList "WriteRegResponse" [
+            // the client needs to keep track
+            // of the transaction, the offset and requested quantity
+            // so much complexity to save a few bytes!
+            test "high offset and value" {
+                let t : WriteRegResponse = {
+                    Offset = 0x3D20us
+                    Value = 0xABCDus
+                }
+
+                let expected =
+                  [
+                    6uy;
+                    0x3Duy;
+                    0x20uy;
+                    0xABuy;
+                    0xCDuy;
+                  ]
+
+                Expect.equal
+                  (t.Serialize ())
+                  expected
+                  "[6uy; 3Duy; 20uy; 0xABuy; 0xCDuy]"
+            }
+
+        ]
+
+        testList "WriteDosResponse" [
+            // the client needs to keep track
+            // of the transaction, the offset and requested quantity
+            // so much complexity to save a few bytes!
+            test "high offset and value" {
+                let t : WriteDosResponse = {
+                    Offset = 0x3D20us
+                    Count = 20us
+                }
+
+                let expected =
+                  [
+                    15uy;
+                    0x3Duy;
+                    0x20uy;
+                    0x00uy;
+                    20uy;
+                  ]
+
+                Expect.equal
+                  (t.Serialize ())
+                  expected
+                  "[15uy; 3Duy; 20uy; 0x00uy; 0x20uy]"
+            }
+
+        ]
+
+        testList "WriteRegsResponse" [
+            // the client needs to keep track
+            // of the transaction, the offset and requested quantity
+            // so much complexity to save a few bytes!
+            test "high offset and value" {
+                let t : WriteRegsResponse = {
+                    Offset = 0x3D20us
+                    Count = 20us
+                }
+
+                let expected =
+                  [
+                    16uy;
+                    0x3Duy;
+                    0x20uy;
+                    0x00uy;
+                    20uy;
+                  ]
+
+                Expect.equal
+                  (t.Serialize ())
+                  expected
+                  "[16uy; 3Duy; 20uy; 0x00uy; 0x20uy]"
+            }
+
+        ]
+
+        testList "Mbap" [
+            test "wrapPdu" {
+                let res : WriteRegsResponse = {
+                    Offset = 0x3D20us
+                    Count = 20us
+                }
+
+                let mockReqMbap  = {
+                    TransactionIdentifier = 0x3234us
+                    ProtocolIdentifier = 0us
+                    Length = 20us
+                    UnitIdentifier = 1uy
+
+                }
+
+                let pdu = res.Serialize ()
+
+                let t = Mbap.wrapPdu mockReqMbap pdu
+
+                let e = [
+                    0x32uy; // trans id msB
+                    0x34uy; // trans id lsB
+                    00uy;   // protocol id msB (should be zero)
+                    00uy;   // protocol id lsB (should be zero)
+                    00uy; // length msB
+                    06uy; // length lsB
+
+            (* 1 *) 01uy; // unit id
+            (* 2 *) 16uy; // function code
+            (* 3 *) 0x3Duy;  // offset msB
+                    0x20uy;  // offset lsB
+                    0x00uy;  // count msB
+            (* 6 *) 20uy;    // count lsB
+                ]
+
+                Expect.equal t e ""
+            }
+
+        ]
+
+
     ]

--- a/tests/tests.fs
+++ b/tests/tests.fs
@@ -17,5 +17,5 @@ let runTests =
     // i run sequenced simply so the output summary is in order,
     // this means tests will run slightly longer, but i doubt it will be 
     // bothersome
-    return runTestsWithArgs defaultConfig [|"--summary"; "--sequenced"|] tests
+    return runTestsWithArgs defaultConfig [|"--summary"; "--sequenced";|] tests
   }


### PR DESCRIPTION
I tried to cherry pick changes, but git wouldn't let me split the
tryParse changes from the serialization changes, so i've added
everything. Not ideal, i know

Try parse now returns a result type of Result<{WhatWeWant}, PDU * exn>
This is much better as failed parsing can now be handled
Furthermore, a failure to parse a message will not crash the thread

Everything has serialization, this makes sense for a number of reasons,
- There is a lot of overlap between the client and the server types,
- Therefore it makes sense for the client and server components to exist
in the same library
- Consequently, each type needs serialization and deserialization
- Having serialization and deserialization means i can test full
round-trip exchanges

Serialization now has 100% test coverage

- The deserialization is the next step to add test coverage for
- Write round-trip tests
- Write some client logic
- Write some integration testing
- Flesh out exception messages
- Write exception test coverage
- Split the program into a different project so the existing project can
be converted to a library (this is nice because you get a working
example, and a runnable test-suite with the library)