### PR TITLE
removes Invalid FunctionCode, adds more deserialization

### DIFF
--- a/Library/tests/Serialization.fs
+++ b/Library/tests/Serialization.fs
@@ -767,10 +767,7 @@ let tests =
         ]
 
         testList "ModError" [
-            // the client needs to keep track
-            // of the transaction, the offset and requested quantity
-            // so much complexity to save a few bytes!
-            test "valid" {
+            test "ReadDO, Illegal Address" {
                 let t : ModError = {
                     FunctionCode = FunctionCode.ReadDO
                     ExceptionCode = ExceptionCode.IllegalDataAddress


### PR DESCRIPTION
The Invalid FunctionCode and Exception code is outside of the modbus
specification.

It was a code-smell to have it in

A much better way is to remain in-spec with the standard, but use a
result type to capture the garbage data

Consequently, the map request to response function now responds to
un-parsable data by killing the connection with the client.

Furthermore, this forced improvements with the validatePdu function,
yielding Modbus Error types that reflect the request type (inclusion of
the ExceptionCode is still not covered, however this brings us a lot
closer)

I will probably update the TryParse methods, to return Result<Request,
ExceptionCode * exn> instead of Result<Request, PDU * exn>,
This way knowledge of what's valid for a function code stays with the
type.

I will probably change mod funcs to the type Result<_Response,
ExceptionCode>, so that ModErrors can be raised by the business logic,
(i.e. address out of range)