### PR TITLE
feat: The library is MBap Request and Response focused

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Library/bin/**
 Library/obj/**
 Docker*/
 Docker*
+
+obj/**

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,6 +12,17 @@
                 "reveal": "silent"
             },
             "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet publish -c Release",
+            "type": "shell",
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
         }
+
     ]
 }

--- a/Example/Program.fs
+++ b/Example/Program.fs
@@ -9,10 +9,10 @@ open System
 let main argv =
   let shouldTest = argv |> Seq.tryFind (fun x -> x.ToLower() = "test") |> Option.isSome
   let runApp = argv |> Seq.tryFind (fun x -> x.ToLower() = "run") |> Option.isSome
-  
-  let conf = 
-    argv 
-    |> Seq.tryFind (fun x -> x.ToLower().Contains("binding")) 
+
+  let conf =
+    argv
+    |> Seq.tryFind (fun x -> x.ToLower().Contains("binding"))
     |> Option.map (fun x -> x.Split('=') |> Seq.last)
     |> Option.defaultValue "tcp://127.0.0.1:5502"
     |> ModbusTypes.ModbusServerConf.TryParse
@@ -22,8 +22,8 @@ let main argv =
   let mutable hReg = [0..100] |> List.map(fun x -> x, 0us) |> Map.ofList
   let mutable iReg = [0..100] |> List.map(fun x -> x, 0us) |> Map.ofList
 
-  let readHRegFunc (x : ReqOffQuant) : ResRegs = 
-    let b = x.Offset |> int
+  let readHRegFunc (x : ReqOffQuant) : ResRegs =
+    let b = x.Address |> int
     let c = x.Quantity |> int
     let e = b + c - 1
     let values : UInt16 list = [b..e] |> List.map (fun x -> Map.find x hReg )
@@ -31,20 +31,20 @@ let main argv =
       Values = values
     }
 
-  let writeRegFunc (x : WriteRegRequest) : WriteRegResponse = 
-    let o = x.Offset |> int
+  let writeRegFunc (x : WriteRegRequest) : WriteRegResponse =
+    let o = x.Address |> int
 
     hReg
     |> Map.add o x.Value
     |> fun y -> hReg <- y
 
     {
-      Offset = x.Offset
+      Address = x.Address
       Value = hReg |> Map.find o
     }
 
-  let writeRegsFunc (x : WriteRegsRequest) : ResOffQuant = 
-     let o = x.Offset |> int
+  let writeRegsFunc (x : WriteRegsRequest) : ResOffQuant =
+     let o = x.Address |> int
      let c = x.Quantity |> int
      let vals = x.Values
      [0..(c-1)]
@@ -52,11 +52,11 @@ let main argv =
      |> ignore
      {
        Quantity = x.Quantity
-       Offset = x.Offset
+       Address = x.Address
      }
 
-  let readDOFunc (x : ReqOffQuant) : ResBools = 
-    let offset = x.Offset |> int
+  let readDOFunc (x : ReqOffQuant) : ResBools =
+    let offset = x.Address |> int
     let count = x.Quantity |> int
     let ``end`` = offset + count - 1
     let values : bool list = [offset..``end``] |> List.map (fun x -> Map.find x dos)
@@ -64,64 +64,82 @@ let main argv =
       Status = values
     }
 
-  let writeDOFunc (x : WriteDoRequest) : WriteDoResponse = 
-    let start = x.Offset |> int
-    dos 
+  let writeDOFunc (x : WriteDoRequest) : WriteDoResponse =
+    let start = x.Address |> int
+    dos
     |> Map.add start x.Value
-    |> fun x -> dos <- x      
-    {      
-      Offset = x.Offset       
+    |> fun x -> dos <- x
+    {
+      Address = x.Address
       Value = dos |> Map.find start
     }
 
-  let writeDOsFunc (x : WriteDosRequest) : ResOffQuant = 
-    let offset = x.Offset |> int
+  let writeDOsFunc (x : WriteDosRequest) : ResOffQuant =
+    let offset = x.Address |> int
     let qty = x.Quantity |> int
     let vals = x.Values
-    [0..(qty-1)] 
+    [0..(qty-1)]
     |> List.map(fun x -> dos |> Map.add (offset + x) (vals |> List.item x) |> fun x -> dos <- x) // hacky!
     |> ignore
     {
-      Offset = x.Offset
+      Address = x.Address
       Quantity = x.Quantity
     }
 
-  let actionFunc : ModFunc = 
-    let r (req : Request) : Response =
-      match req with 
+  let actionFunc : ModFunc =
+    let r (req : RtuRequest) : RtuResponse =
+      match req with
       | ReadDOReq x -> readDOFunc x |> ReadDORes
-      | ReadDIReq x -> ModFunc.Default.Success.readDIFunc x 
+      | ReadDIReq x -> ModFunc.Default.Success.readDIFunc x
       | ReadHRegReq x -> readHRegFunc x |> ReadHRegRes
-      | ReadIRegReq x -> ModFunc.Default.Success.readIRegFunc x 
+      | ReadIRegReq x -> ModFunc.Default.Success.readIRegFunc x
       | WriteDOReq x -> writeDOFunc x |> WriteDORes
       | WriteRegReq x -> writeRegFunc x |> WriteRegRes
       | WriteDOsReq x -> writeDOsFunc x |> WriteDOsRes
-      | WriteRegsReq x -> ModFunc.Default.Success.writeRegsFunc x
+      | WriteRegsReq x -> writeRegsFunc x |> WriteRegsRes
     r
 
-  let conf = 
-    conf |> function | Ok x -> x // okay to crash here
-  
-  let modServer = Modbus.server conf actionFunc
+  let actionFunc : MbapFunc =
+    let r (req : MbapReq ) : Result<MbapRes, unit> =
 
-  let app = 
-    match runApp, shouldTest with 
-    | true, _ -> 
-      modServer >>- (fun x -> 0)
-    | false, false -> 
-      modServer >>- (fun x -> 0)
-    | _ -> 
+      match req.UnitIdentifier with
+      | 0uy ->
+        // we're only interested in one unit, which is '0',
+        // although we can have as many units as we want
+        let res =
+          req.Request
+          |> actionFunc
+
+        {
+          TransactionIdentifier = req.TransactionIdentifier
+          ProtocolIdentifier = req.ProtocolIdentifier
+          UnitIdentifier = req.UnitIdentifier
+          Response = res
+        } |> Ok
+      | _ -> () |> Error
+    r
+
+
+  let app =
+    match runApp, conf, shouldTest with
+    | true, Ok conf, _ ->
+      let modServer = Modbus.server conf actionFunc
+      modServer >>- (fun () -> 0)
+    | false, Ok conf, false ->
+      let modServer = Modbus.server conf actionFunc
+      modServer >>- (fun () -> 0)
+    | _ ->
       0 |> Job.result
 
   let tests =
     match shouldTest with
-    | true -> 
+    | true ->
       Tests.runTests
-    | false -> 
+    | false ->
       0 |> Job.result
 
-  [app; tests] 
+  [app; tests]
   |> Job.conCollect
-  |> Hopac.run 
-  |> Seq.tryFind (fun x -> x <> 0) 
+  |> Hopac.run
+  |> Seq.tryFind (fun x -> x <> 0)
   |> Option.defaultValue 0

--- a/Library/Modbus.fs
+++ b/Library/Modbus.fs
@@ -3,70 +3,61 @@ module Modbus
 
 open ModbusTypes
 open System
-open System.Threading
-open Util
-
-let validateMbap (slaveId : byte) (frame : byte []) : PDU * Mbap =
-  // the smallest frame is 12 bytes long
-  if frame.Length < 12 then
-    FormatException("Frame length less than the minimum of 12") |> raise
-  let frame = frame |> Array.toList
-  let (TidH :: TidL :: PiH :: PiL :: LH :: LL :: Ui :: Pdu) = frame
-  let length = [LL; LH; 0uy; 0uy] |> tI32
-  let lengthU = [LL; LH] |> tU16
-  let mbap : Mbap =
-    {
-      Length = lengthU
-      ProtocolIdentifier = [PiL; PiH] |> tU16
-      TransactionIdentifier = [TidL; TidH] |> tU16
-      UnitIdentifier = Ui
-    }
-
-  // verify the length
-  if (frame.Length - 6) <> length then
-    FormatException("Frame is reporting a different length than received") |> raise
-
-  if slaveId <> Ui then
-    FormatException(sprintf "This slave is %i, requested slave is %i" slaveId Ui) |> raise
-
-  if PiL <> 0uy || PiH <> 0uy then
-    FormatException("Protocol identifier is expected to be zero") |> raise
-
-  Pdu, mbap
 
 open Hopac
+open Hopac.Infixes
+
 open System.Net
 open System.Net.Sockets
-let rec handleReceive (slaveId : byte) (handle : Socket) (func : ModFunc) : Job<unit> =
+
+let rec handleReceive (handle : Socket) (func : MbapFunc) : Job<unit> =
   job {
-    let buff : Memory<byte> = Memory(Array.zeroCreate(300))
-    let! len = handle.ReceiveAsync(buff, SocketFlags.None, CancellationToken(false)).AsTask()
-    match handle.Connected && len <> 0 with
-      | true ->
-        let frame = buff.Slice(0, len).ToArray()
-        let (pdu, mbap) = validateMbap slaveId frame
-        let request = Request.TryParse pdu
-        match request with
-        | Ok r ->
-          let response = r |> func
-          let resPdu = response.Serialize()
-          let rawRes = Mbap.wrapPdu mbap resPdu |> List.toArray
-          let outBuff = rawRes |> ReadOnlyMemory
-          let! _ = handle.SendAsync(outBuff, SocketFlags.None, CancellationToken()).AsTask()
-          do! handleReceive slaveId handle func
-        | Error _ ->
+    let inBuff : ArraySegment<byte> = Array.zeroCreate(300) |> ArraySegment
+    let mutable keepGoing = true
+    while keepGoing do
+      let! len = (fun () -> handle.ReceiveAsync(inBuff, SocketFlags.None )) |> Job.fromTask
+
+      try
+        match handle.Connected && len > 0 with
+          | true ->
+            let frame = inBuff.Slice(0, len).ToArray() |> Array.toList
+            let reqMbap = MbapReq.TryParse frame
+            match reqMbap with
+            | Ok r ->
+              let res = func r
+              match res with
+              | Error _ -> exn "error responding to request" |> raise
+              | Ok res ->
+                let buff =
+                  res
+                  |> (fun x -> x.Serialize())
+                  |> List.toArray
+                  |> ArraySegment
+
+                do! (fun () -> handle.SendAsync(buff, SocketFlags.None)) |> Job.fromTask >>- ignore
+            | Error _ ->
+              exn "unable to parse request" |> raise
+          | false ->
+            exn "not connected to client" |> raise
+      with
+      | _ ->
+        try
           handle.Disconnect(true)
+        with | _ -> ()
+
+        try
           handle.Dispose()
-      | false ->
-        handle.Disconnect(true)
-        handle.Dispose()
+        with | _ -> ()
+
+        keepGoing <- false
+
   } |> Job.startIgnore
 
-let server (conf : ModbusServerConf) (actionFunc : ModFunc) : Job<unit> =
+let server (conf : ModbusServerConf) (actionFunc : MbapFunc) : Job<unit> =
   let listener = new Socket(SocketType.Stream, ProtocolType.Tcp)
   listener.Bind(IPEndPoint(conf.IPAddress, int conf.Port))
   listener.Listen(100)
   job {
     let! handler = listener.AcceptAsync()
-    do! handleReceive conf.SlaveId handler actionFunc
+    do! handleReceive handler actionFunc
   } |> Job.foreverIgnore

--- a/Library/Util.fs
+++ b/Library/Util.fs
@@ -1,22 +1,26 @@
 module Util
 // for my code, the head should always be the least significant
 
-open System 
+open System
+#nowarn "25"
+// okay to crash if the pattern doesn't match,
+// may be better to take a byte list and attempt the pattern matching inside a try-with?
+// returning a result type..
 
-let tU32 [a; b; c; d] = BitConverter.ToUInt32([|a; b; c; d|],0)
-let tI32 [a; b; c; d] = BitConverter.ToInt32([|a; b; c; d|],0)
+let tU32 (a :: b :: c :: [d]) = BitConverter.ToUInt32([|a; b; c; d|],0)
+let tI32 (a :: b :: c :: [d]) = BitConverter.ToInt32([|a; b; c; d|],0)
 
-let tU16 [a; b] = BitConverter.ToUInt16([|a; b|],0)
-let tI16 [a; b] = BitConverter.ToInt16([|a; b|],0)
+let tU16 (a :: [b]) = BitConverter.ToUInt16([|a; b|],0)
+let tI16 (a :: [b]) = BitConverter.ToInt16([|a; b|],0)
 
 let byteToBool (x : byte) =
   [0..7] |> List.map (fun y -> x >>> y &&& 1uy = 1uy)
 
-let bytesToBool (x : byte list) = 
+let bytesToBool (x : byte list) =
   x |> List.fold (fun x y -> x @ byteToBool y ) []
 
-let bytesToUint16 (x : byte list) = 
-  List.foldBack (fun x (l,r) -> x::r, l) x ([],[]) 
+let bytesToUint16 (x : byte list) =
+  List.foldBack (fun x (l,r) -> x::r, l) x ([],[])
   |> fun (high,low) -> List.zip low high
   |> List.map (fun (high,low) -> [low; high] |> tU16)
 
@@ -29,44 +33,44 @@ let BoolToByte (x : bool) =
 
 // the resulting list should have the lowest value
 // bytes at head, i.e. [1..32] -> [1->8]@[9->16]@[17->24]@[25->32]
-let BoolsToBytes (bList : bool list) : byte list = 
+let BoolsToBytes (bList : bool list) : byte list =
   let byteCount = ((bList |> List.length) - 1) / 8 + 1
-  [1..byteCount] 
+  [1..byteCount]
   |> List.map (
-       fun x -> 
+       fun x ->
          let byteIndexes = [0..7]
-         
-         let a = 
+
+         let a =
            byteIndexes
-           |> List.map (fun y -> (x - 1) * 8 + y, y) 
-         
-         let b = 
-           a 
+           |> List.map (fun y -> (x - 1) * 8 + y, y)
+
+         let b =
+           a
            |> List.map (fun (x,y) -> (bList |> List.tryItem(x) |> function | Some x -> x | _ -> false),y)
-         
+
          let c =
            b
            |> List.fold (fun a (n, i) -> (BoolToByte n) <<< i |> (+) a) 0uy
-          
+
          c
     )
 
-let U16ToBytes (x : UInt16) : byte list = 
+let U16ToBytes (x : UInt16) : byte list =
   let b1 = x |> byte
   let b2 = (x - (b1 |> uint16)) >>> 8 |> byte
   [b1; b2]
 
-let U16sToBytes : UInt16 list -> byte list = 
+let U16sToBytes : UInt16 list -> byte list =
   List.map U16ToBytes >> List.concat
 
-let BoolToUint16 : bool -> UInt16 = 
+let BoolToUint16 : bool -> UInt16 =
   function | false -> 0us | true -> 255us <<< 8
-  
-let swapU16s (x : byte list) : byte list = 
+
+let swapU16s (x : byte list) : byte list =
   let len = (x |> List.length) / 2
   [0..len-1]
   |> List.map (
-       fun y -> 
+       fun y ->
           let a = x |> List.item (y * 2 )
           let b = x |> List.item (y * 2 + 1)
           a,b

--- a/Library/tests/Deserialization.fs
+++ b/Library/tests/Deserialization.fs
@@ -7,7 +7,7 @@ open ModbusTypes
 let tests =
     testList "Deserialization" [
       testList "ModError" [
-        test "parses" {
+        test "valid mod error" {
             let t = ModError.TryParse [0x81uy; 0x02uy]
             let e =
               {
@@ -16,7 +16,7 @@ let tests =
               } |> Ok
             Expect.equal t e "Should have ReadDO and Illegal Address"
         }
-        test "parse fail no error flag" {
+        test "no error flag" {
             let pdu = [0x01uy; 0x01uy]
             let t = ModError.TryParse pdu
             let t =
@@ -32,7 +32,7 @@ let tests =
             let e = (pdu, ex) |> Error |> sprintf "%A"
             Expect.equal t e "Should return a 'no error flag' error"
         }
-        test "parse fail junk function code" {
+        test "junk function code" {
             let pdu = [0x89uy; 0x01uy]
             let t = ModError.TryParse pdu
             let t =
@@ -48,7 +48,7 @@ let tests =
             let e = (pdu, ex) |> Error |> sprintf "%A"
             Expect.equal t e "Should return function code invalid error"
         }
-        test "parse complete junk" {
+        test "complete junk" {
             let pdu = [0x89uy; 0x55uy]
             let t = ModError.TryParse pdu
             let t =
@@ -64,7 +64,11 @@ let tests =
             let e = (pdu, ex) |> Error |> sprintf "%A"
             Expect.equal t e "Should return a 'no error flag' error"
         }
-        test "parse long junk" {
+
+        // todo: failure to parse means an invalid pdu,
+        // if the exception is "The match cases were incomplete"
+        // change to "Invalid Frame"
+        test "long junk" {
             let pdu = [0x89uy; 0x55uy; 0x19uy]
             let t = ModError.TryParse pdu
             let t =
@@ -81,213 +85,12 @@ let tests =
             Expect.equal t e "Incomplete match case"
         }
       ]
-      (*
+
       testList "ReadDoRequest" [
-        test "parse ok" {
-          let payload = [1uy; 2uy; 4uy; 4uy; 1uy]
-          let e : ReadDoRequest = {
-              Offset = 0x0204us
-              Quantity = 0x0401us
-            } 
+        test "valid" {
 
-          let e : Result<ReadDoRequest, PDU * exn> = e |> Ok
-          
-          let t = ReadDoRequest.TryParse payload
-          Expect.equal e t "Valid ReadDoRequest "
+          Expect.equal 1 1 ""
         }
-
-
-        test "parse fail short" {
-          let payload = [1uy; 2uy; 4uy;]
-          let t = ReadDoRequest.TryParse payload
-          Expect.isError t "Should be error"
-          
-          let (pdu, exT) = 
-            t 
-            |> function 
-               | Result.Error x ->  x 
-               | _ -> [], Exception()
-          
-          Expect.equal pdu payload "the pdu should be returned"
-          
-          let exT = exT.GetType()
-          let exT1 = MatchFailureException("",0,0).GetType()
-          Expect.equal exT exT1 "We are expecting a Match Failure Exception"
-        }
-
-        test "parse fail long" {
-          let payload = [1uy; 2uy; 4uy; 2uy; 2uy; 5uy]
-          let t = ReadDoRequest.TryParse payload
-          Expect.isError t "Should be error"
-          
-          let (pdu, exT) = 
-            t 
-            |> function 
-               | Result.Error x ->  x 
-               | _ -> [], Exception()
-          
-          Expect.equal pdu payload "the pdu should be returned"
-          
-          let exT = exT.GetType()
-          let exT1 = MatchFailureException("",0,0).GetType()
-          Expect.equal exT exT1 "We are expecting a Match Failure Exception"
-        }        
       ]
 
-      testList "ReadDiRequest" [
-        test "parse ok" {
-          let payload = [2uy; 2uy; 4uy; 4uy; 1uy]
-          let e : ReadDiRequest = {
-              Offset = 0x0204us
-              Quantity = 0x0401us
-            } 
-
-          let e : Result<ReadDiRequest, PDU * exn> = e |> Ok
-          
-          let t = ReadDiRequest.TryParse payload
-          Expect.equal e t "Valid ReadDoRequest "
-        }
-
-
-        test "parse fail short" {
-          let payload = [2uy; 2uy; 4uy;]
-          let t = ReadDiRequest.TryParse payload
-          Expect.isError t "Should be error"
-          
-          let (pdu, exT) = 
-            t 
-            |> function 
-               | Result.Error x ->  x 
-               | _ -> [], Exception()
-          
-          Expect.equal pdu payload "the pdu should be returned"
-          
-          let exT = exT.GetType()
-          let exT1 = MatchFailureException("",0,0).GetType()
-          Expect.equal exT exT1 "We are expecting a Match Failure Exception"
-        }
-
-        test "parse fail long" {
-          let payload = [2uy; 2uy; 4uy; 2uy; 2uy; 5uy]
-          let t = ReadDiRequest.TryParse payload
-          Expect.isError t "Should be error"
-          
-          let (pdu, exT) = 
-            t 
-            |> function 
-               | Result.Error x ->  x 
-               | _ -> [], Exception()
-          
-          Expect.equal pdu payload "the pdu should be returned"
-          
-          let exT = exT.GetType()
-          let exT1 = MatchFailureException("",0,0).GetType()
-          Expect.equal exT exT1 "We are expecting a Match Failure Exception"
-        }        
-      ]
-      
-      testList "ReadHRegRequest" [
-        test "parse ok" {
-          let payload = [3uy; 2uy; 4uy; 4uy; 1uy]
-          let e : ReadHRegRequest = {
-              Offset = 0x0204us
-              Quantity = 0x0401us
-            } 
-
-          let e : Result<ReadHRegRequest, PDU * exn> = e |> Ok
-          
-          let t = ReadHRegRequest.TryParse payload
-          Expect.equal e t "Valid ReadDoRequest "
-        }
-
-
-        test "parse fail short" {
-          let payload = [3uy; 2uy; 4uy;]
-          let t = ReadHRegRequest.TryParse payload
-          Expect.isError t "Should be error"
-          
-          let (pdu, exT) = 
-            t 
-            |> function 
-               | Result.Error x ->  x 
-               | _ -> [], Exception()
-          
-          Expect.equal pdu payload "the pdu should be returned"
-          
-          let exT = exT.GetType()
-          let exT1 = MatchFailureException("",0,0).GetType()
-          Expect.equal exT exT1 "We are expecting a Match Failure Exception"
-        }
-
-        test "parse fail long" {
-          let payload = [3uy; 2uy; 4uy; 2uy; 2uy; 5uy]
-          let t = ReadDiRequest.TryParse payload
-          Expect.isError t "Should be error"
-          
-          let (pdu, exT) = 
-            t 
-            |> function 
-               | Result.Error x ->  x 
-               | _ -> [], Exception()
-          
-          Expect.equal pdu payload "the pdu should be returned"
-          
-          let exT = exT.GetType()
-          let exT1 = MatchFailureException("",0,0).GetType()
-          Expect.equal exT exT1 "We are expecting a Match Failure Exception"
-        }        
-      ]
-
-      testList "ReadIRegRequest" [
-        test "parse ok" {
-          let payload = [4uy; 2uy; 4uy; 4uy; 1uy]
-          let e : ReadIRegRequest = {
-              Offset = 0x0204us
-              Quantity = 0x0401us
-            } 
-
-          let e : Result<ReadIRegRequest, PDU * exn> = e |> Ok
-          
-          let t = ReadIRegRequest.TryParse payload
-          Expect.equal e t "Valid ReadDoRequest "
-        }
-
-
-        test "parse fail short" {
-          let payload = [4uy; 2uy; 4uy;]
-          let t = ReadIRegRequest.TryParse payload
-          Expect.isError t "Should be error"
-          
-          let (pdu, exT) = 
-            t 
-            |> function 
-               | Result.Error x ->  x 
-               | _ -> [], Exception()
-          
-          Expect.equal pdu payload "the pdu should be returned"
-          
-          let exT = exT.GetType()
-          let exT1 = MatchFailureException("",0,0).GetType()
-          Expect.equal exT exT1 "We are expecting a Match Failure Exception"
-        }
-
-        test "parse fail long" {
-          let payload = [4uy; 2uy; 4uy; 2uy; 2uy; 5uy]
-          let t = ReadDiRequest.TryParse payload
-          Expect.isError t "Should be error"
-          
-          let (pdu, exT) = 
-            t 
-            |> function 
-               | Result.Error x ->  x 
-               | _ -> [], Exception()
-          
-          Expect.equal pdu payload "the pdu should be returned"
-          
-          let exT = exT.GetType()
-          let exT1 = MatchFailureException("",0,0).GetType()
-          Expect.equal exT exT1 "We are expecting a Match Failure Exception"
-        }        
-      ]
-      *)
     ]

--- a/Library/tests/Serialization.fs
+++ b/Library/tests/Serialization.fs
@@ -79,7 +79,7 @@ let tests =
         testList "WriteDoRequest" [
             test "LSB Only true" {
                 let t : WriteDoRequest = {
-                    Offset = 32us
+                    Address = 32us
                     Value = true
                 }
                 Expect.equal
@@ -89,7 +89,7 @@ let tests =
             }
             test "LSB Only false" {
                 let t : WriteDoRequest = {
-                    Offset = 32us
+                    Address = 32us
                     Value = false
                 }
                 Expect.equal
@@ -99,7 +99,7 @@ let tests =
             }
             test "LSB&MSB true" {
                 let t : WriteDoRequest = {
-                    Offset = 512us + 32us
+                    Address = 512us + 32us
                     Value = true
                 }
                 Expect.equal
@@ -111,7 +111,7 @@ let tests =
         testList "WriteRegRequest" [
             test "LSB Only" {
                 let t : WriteRegRequest = {
-                    Offset = (0x00us <<< 8) + 0x32us
+                    Address = (0x00us <<< 8) + 0x32us
                     Value = (0x00us <<< 8) + 0x55us
                 }
                 Expect.equal
@@ -121,7 +121,7 @@ let tests =
             }
             test "LSBs & MSB" {
                 let t : WriteRegRequest = {
-                    Offset = (0x66us <<< 8) + 0x32us
+                    Address = (0x66us <<< 8) + 0x32us
                     Value = (0xA9us <<< 8) + 0x55us
                 }
                 Expect.equal
@@ -134,7 +134,7 @@ let tests =
         testList "WriteDosRequest" [
             test "6 values" {
                 let t : WriteDosRequest = {
-                    Offset = (0x66us <<< 8) + 0x32us
+                    Address = (0x66us <<< 8) + 0x32us
                     Quantity = (0x00us <<< 8) + 06us
                     Values = [true; true; true; true; false; false; false; false;]
                 }
@@ -145,7 +145,7 @@ let tests =
             }
             test "8 values" {
                 let t : WriteDosRequest = {
-                    Offset = (0x66us <<< 8) + 0x32us
+                    Address = (0x66us <<< 8) + 0x32us
                     Quantity = (0x00us <<< 8) + 08us
                     Values = [true; true; true; true; false; false; false; true;]
                 }
@@ -156,7 +156,7 @@ let tests =
             }
             test "12 values" {
                 let t : WriteDosRequest = {
-                    Offset = (0x66us <<< 8) + 0x32us
+                    Address = (0x66us <<< 8) + 0x32us
                     Quantity = (0x00us <<< 8) + 12us
                     Values =
                       [
@@ -186,7 +186,7 @@ let tests =
             }
             test "20 values" {
                 let t : WriteDosRequest = {
-                    Offset = (0x66us <<< 8) + 0x32us
+                    Address = (0x66us <<< 8) + 0x32us
                     Quantity = (0x00us <<< 8) + 20us
                     Values =
                       [
@@ -225,7 +225,7 @@ let tests =
             }
             test "240 values" {
                 let t : WriteDosRequest = {
-                    Offset = (0x66us <<< 8) + 0x32us
+                    Address = (0x66us <<< 8) + 0x32us
                     Quantity = 1920us
                     Values = [0..1919] |> List.map (fun x -> x % 2 = 0)
                 }
@@ -242,7 +242,7 @@ let tests =
         testList "WriteRegsRequest" [
             test "1 value" {
                 let t : WriteRegsRequest = {
-                    Offset = (0x66us <<< 8) + 0x32us
+                    Address = (0x66us <<< 8) + 0x32us
                     Quantity = (0x00us <<< 8) + 01us
                     Values = [1us]
                 }
@@ -253,7 +253,7 @@ let tests =
             }
             test "2 large values" {
                 let t : WriteRegsRequest = {
-                    Offset = (0x66us <<< 8) + 0x32us
+                    Address = (0x66us <<< 8) + 0x32us
                     Quantity = (0x00us <<< 8) + 02us
                     Values = [33003us; 18711us] // head = least sig
                     // 80 EB 49 17
@@ -266,7 +266,7 @@ let tests =
             test "120 values" {
                 let v = [1us..120us] |> List.map ((*) 200us) // head = least sig
                 let t : WriteRegsRequest = {
-                    Offset = (0x66us <<< 8) + 0x32us
+                    Address = (0x66us <<< 8) + 0x32us
                     Quantity = (0x00us <<< 8) + 120us
                     Values = v
                 }
@@ -280,11 +280,11 @@ let tests =
 
         testList "WriteDoResponse" [
             // the client needs to keep track
-            // of the transaction, the offset and requested quantity
+            // of the transaction, the Address and requested quantity
             // so much complexity to save a few bytes!
             test "true" {
                 let t : WriteDoResponse = {
-                    Offset = 0x20us
+                    Address = 0x20us
                     Value = true
                 }
 
@@ -305,7 +305,7 @@ let tests =
 
             test "false" {
                 let t : WriteDoResponse = {
-                    Offset = 0x20us
+                    Address = 0x20us
                     Value = false
                 }
 
@@ -326,7 +326,7 @@ let tests =
 
             test "true high address" {
                 let t : WriteDoResponse = {
-                    Offset = 0x2120us
+                    Address = 0x2120us
                     Value = true
                 }
 
@@ -348,11 +348,11 @@ let tests =
 
         testList "WriteRegResponse" [
             // the client needs to keep track
-            // of the transaction, the offset and requested quantity
+            // of the transaction, the Address and requested quantity
             // so much complexity to save a few bytes!
-            test "high offset and value" {
+            test "high Address and value" {
                 let t : WriteRegResponse = {
-                    Offset = 0x3D20us
+                    Address = 0x3D20us
                     Value = 0xABCDus
                 }
 


### PR DESCRIPTION
The library is unopinionated about how to work with modbus

The user should supply a delegate of MBapRequest to Result<MBapResponse,
()>

This can probably be more useful to use exception, etc, but there's
enough here to get started.

What i don't like about this library is i can't find a way to keep the
memory usage down, on my laptop (ubuntu with 16GB ram) the debug version
of the program will use up to 1.7GB. I know this business-as-usual with
dotnet but i can see no reason why the ram usage is so high!

I was smashing the server with up to 400 requests per second (reading
and writing) and CPU usage was well below 10%.

I would like to compile this for and run it on a raspberry pi, i think
this could work very nicely with an rPi

The next step is to write a basic client, since all of the serialization
and deserialization has been taken care of this should be fairly simple.

I will try to make smaller, better documented commits

ToDo:
Write the client
Restore testing
Improve 'exception handling'
Add logging
Add round-trip testing